### PR TITLE
ft_setenvのメモリリークを解消しました。

### DIFF
--- a/src/bltin/export.c
+++ b/src/bltin/export.c
@@ -84,12 +84,11 @@ int minishell_export(char **argv, t_shell *shell)
 			value = get_shell_var(shell, str[0]);
 			if (value == NULL)
 				value = "";
-			//ft_setenv(str[0], value);
-			setenv(str[0], value, 1);
+			ft_setenv(str[0], value);
+			// setenv(str[0], value, 1);
 			dp_free(str);
 			i++;
 		}
 	}
 	return (0);
-	setenv(str[0], value, 1);
 }

--- a/src/bltin/export.c
+++ b/src/bltin/export.c
@@ -85,7 +85,7 @@ int minishell_export(char **argv, t_shell *shell)
 			if (value == NULL)
 				value = "";
 			ft_setenv(str[0], value);
-			// setenv(str[0], value, 1);
+			//setenv(str[0], value, 1);
 			dp_free(str);
 			i++;
 		}

--- a/src/libft/ft_setenv.c
+++ b/src/libft/ft_setenv.c
@@ -1,20 +1,21 @@
 #include "../../includes/libft.h"
 
+static char **last_environ;
+
 static void add_to_environ(char *param)
 {
 	extern char	**environ;
 	char		**new_environ;
 	int			size;
 
+	last_environ = NULL;
 	size = 0;
 	while (environ[size] != NULL)
 		size++;
 	new_environ = (char **)ft_calloc((size + 2), sizeof(char *));
 	ft_memcpy(new_environ, environ, sizeof(char*) * size);
 	new_environ[size] = param;
-	if ((void*)environ < (void*)&new_environ)
-		free(environ);
-	environ = new_environ;
+	last_environ = environ = new_environ;
 }
 
 int	ft_setenv(char *name, char *value)
@@ -39,12 +40,12 @@ int	ft_setenv(char *name, char *value)
 	{
 		if (!ft_strncmp(*ep, name, namelen) && (*ep)[namelen] == '=')
 		{
+			free(*ep);
 			*ep = new_value;
 			return (0);
 		}
 		ep++;
 	}
 	add_to_environ(new_value);
-	// free(new_value);
 	return (0);
 }

--- a/src/libft/ft_setenv.c
+++ b/src/libft/ft_setenv.c
@@ -1,20 +1,5 @@
 #include "../../includes/libft.h"
 
-// static char	**ft_clear(char ***ans)
-// {
-// 	unsigned int	i;
-
-// 	i = 0;
-// 	while ((*ans)[i])
-// 	{
-// 		free((*ans)[i]);
-// 		(*ans)[i++] = NULL;
-// 	}
-// 	free(*ans);
-// 	*ans = NULL;
-// 	return (NULL);
-// }
-
 static void add_to_environ(char *param)
 {
 	extern char	**environ;

--- a/src/libft/ft_setenv.c
+++ b/src/libft/ft_setenv.c
@@ -1,24 +1,34 @@
 #include "../../includes/libft.h"
 
+// static char	**ft_clear(char ***ans)
+// {
+// 	unsigned int	i;
+
+// 	i = 0;
+// 	while ((*ans)[i])
+// 	{
+// 		free((*ans)[i]);
+// 		(*ans)[i++] = NULL;
+// 	}
+// 	free(*ans);
+// 	*ans = NULL;
+// 	return (NULL);
+// }
+
 static void add_to_environ(char *param)
 {
 	extern char	**environ;
 	char		**new_environ;
 	int			size;
-	int			i;
 
 	size = 0;
 	while (environ[size] != NULL)
 		size++;
-	new_environ = (char **)malloc(sizeof(char *) * (size + 2));
-	i = 0;
-	while (environ[i] != NULL)
-	{
-		new_environ[i] = environ[i];
-		i++;
-	}
-	new_environ[i] = param;
-	new_environ[i + 1] = NULL;
+	new_environ = (char **)ft_calloc((size + 2), sizeof(char *));
+	ft_memcpy(new_environ, environ, sizeof(char*) * size);
+	new_environ[size] = param;
+	if ((void*)environ < (void*)&new_environ)
+		free(environ);
 	environ = new_environ;
 }
 
@@ -28,8 +38,7 @@ int	ft_setenv(char *name, char *value)
 	char		**ep;
 	char		*new_value;
 	size_t		namelen;
-	size_t		vallen;	
-	size_t		varlen;	
+	char		*tmp;
 
 	if (name == NULL || *name == '\0' || ft_strchr(name, '=') != NULL)
 	{
@@ -37,12 +46,9 @@ int	ft_setenv(char *name, char *value)
 		return (-1);
 	}
 	namelen = ft_strlen(name);
-	vallen = ft_strlen(value) + 1;
-	varlen = namelen + 1 + vallen;
-	new_value = (char *)malloc(sizeof(char) * varlen);
-	ft_memcpy(new_value, name, namelen);
-	ft_memcpy(&new_value[namelen], "=", 1);
-	ft_memcpy(&new_value[namelen + 1], value, vallen);
+	tmp = ft_strjoin(name, "=");
+	new_value = ft_strjoin(tmp, value);
+	free(tmp);
 	ep = environ;
 	while (*ep != NULL)
 	{
@@ -54,5 +60,6 @@ int	ft_setenv(char *name, char *value)
 		ep++;
 	}
 	add_to_environ(new_value);
+	// free(new_value);
 	return (0);
 }

--- a/src/libft/ft_setenv.c
+++ b/src/libft/ft_setenv.c
@@ -8,14 +8,14 @@ static void add_to_environ(char *param)
 	char		**new_environ;
 	int			size;
 
-	last_environ = NULL;
 	size = 0;
 	while (environ[size] != NULL)
 		size++;
 	new_environ = (char **)ft_calloc((size + 2), sizeof(char *));
 	ft_memcpy(new_environ, environ, sizeof(char*) * size);
 	new_environ[size] = param;
-	last_environ = environ = new_environ;
+	environ = new_environ;
+	last_environ = environ;
 }
 
 int	ft_setenv(char *name, char *value)

--- a/src/libft/ft_unsetenv.c
+++ b/src/libft/ft_unsetenv.c
@@ -44,6 +44,7 @@ int	ft_unsetenv(char *name)
 	adress = get_env_adress(name);
 	if (adress != NULL)
 	{
+		free(*adress);
 		while (*adress)
 		{
 			*adress = *(adress + 1);

--- a/src/minishell.c
+++ b/src/minishell.c
@@ -18,7 +18,6 @@ static void minishell_loop(t_shell *shell)
 void minishell_end(t_shell *shell)
 {
 	int i;
-	extern char **environ;
 
 	i = 0;
 	while (i < HASH_SIZE)
@@ -28,7 +27,6 @@ void minishell_end(t_shell *shell)
 	}
 	shell->hist_lst = ft_dlsttop(shell->hist_lst);
 	ft_dlstclear(&shell->hist_lst, free);
-	free(environ);
 	free(shell->histfile_path);
 	exit(shell->exit_status);
 }

--- a/src/minishell.c
+++ b/src/minishell.c
@@ -13,11 +13,12 @@ static void minishell_loop(t_shell *shell)
 		ft_dlstclear(&line, free);
 		ft_lstclear(&tokens, ip_free);
 	}
-} 
+}
 
 void minishell_end(t_shell *shell)
 {
 	int i;
+	extern char **environ;
 
 	i = 0;
 	while (i < HASH_SIZE)
@@ -27,6 +28,7 @@ void minishell_end(t_shell *shell)
 	}
 	shell->hist_lst = ft_dlsttop(shell->hist_lst);
 	ft_dlstclear(&shell->hist_lst, free);
+	free(environ);
 	free(shell->histfile_path);
 	exit(shell->exit_status);
 }

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -87,6 +87,8 @@ static void lists(t_ip *ip, t_list **tokens, t_list **gmrs)
 				gmr->op = SEMICOLON_OP;
 			next_token(ip, tokens);
 		}
+		else
+			gmr->op = NEWLINE_OP;
 		ft_lstadd_back(gmrs, ft_lstnew(gmr));
 	}
 }


### PR DESCRIPTION
なぜできたかは不明。
pdfでグローバル変数１つだけ使っていいよーって言ってるから理由は説明できればおおけい